### PR TITLE
refactor: Replace "hub" terminology with "station" for better clarity

### DIFF
--- a/custom_components/noaa_tides/__init__.py
+++ b/custom_components/noaa_tides/__init__.py
@@ -33,7 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Create coordinator with proper type hints
     coordinator = NoaaTidesDataUpdateCoordinator(
         hass,
-        hub_type=entry.data[const.CONF_HUB_TYPE],
+        station_type=entry.data[const.CONF_STATION_TYPE],
         station_id=entry.data.get(const.CONF_STATION_ID)
         or entry.data.get(const.CONF_BUOY_ID),
         selected_sensors=entry.data.get("sensors", []),
@@ -59,12 +59,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         name=entry.data.get("name", ""),
         manufacturer=(
             "The National Oceanic & Atmospheric Administration"
-            if entry.data[const.CONF_HUB_TYPE] == const.HUB_TYPE_NOAA
+            if entry.data[const.CONF_STATION_TYPE] == const.STATION_TYPE_NOAA
             else "The National Data Buoy Center"
         ),
         model=(
             f"NOAA Station {coordinator.station_id}"
-            if entry.data[const.CONF_HUB_TYPE] == const.HUB_TYPE_NOAA
+            if entry.data[const.CONF_STATION_TYPE] == const.STATION_TYPE_NOAA
             else f"NDBC Buoy {coordinator.station_id}"
         ),
         entry_type=DeviceEntryType.SERVICE,
@@ -79,7 +79,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Remove the config entry from domain data if initial refresh failed
         hass.data[const.DOMAIN].pop(entry.entry_id)
         source_type = (
-            "NOAA station" if entry.data[const.CONF_HUB_TYPE] == const.HUB_TYPE_NOAA 
+            "NOAA station" if entry.data[const.CONF_STATION_TYPE] == const.STATION_TYPE_NOAA 
             else "NDBC buoy"
         )
         raise ConfigEntryNotReady(

--- a/custom_components/noaa_tides/config_flow.py
+++ b/custom_components/noaa_tides/config_flow.py
@@ -33,7 +33,7 @@ class NoaaTidesConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
         self._data: ConfigFlowData = ConfigFlowData(
             name="",
             sensors=[],
-            hub_type="",
+            station_type="",
             timezone=const.DEFAULT_TIMEZONE,
             unit_system=const.DEFAULT_UNIT_SYSTEM,
             update_interval=const.DEFAULT_UPDATE_INTERVAL,
@@ -63,11 +63,11 @@ class NoaaTidesConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
                     )
                 else:
                     # Successfully detected - store the data and continue
-                    self._data[const.CONF_HUB_TYPE] = detected_type
+                    self._data[const.CONF_STATION_TYPE] = detected_type
                     self._detected_station_id = station_id
 
                     # Set the appropriate ID field based on detected type
-                    if detected_type == const.HUB_TYPE_NOAA:
+                    if detected_type == const.STATION_TYPE_NOAA:
                         self._data[const.CONF_STATION_ID] = station_id
                         _LOGGER.info(
                             f"Auto-detected NOAA Station: {station_id}")
@@ -104,7 +104,7 @@ class NoaaTidesConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
                 _LOGGER.debug(
                     f"Station {station_id} identified as NOAA station ({len(noaa_sensors)} sensors)"
                 )
-                return const.HUB_TYPE_NOAA
+                return const.STATION_TYPE_NOAA
         except Exception as err:
             _LOGGER.debug(
                 f"NOAA sensor discovery failed for {station_id}: {err}")
@@ -118,7 +118,7 @@ class NoaaTidesConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
                 _LOGGER.debug(
                     f"Station {station_id} identified as NDBC buoy ({len(ndbc_sensors)} sensors)"
                 )
-                return const.HUB_TYPE_NDBC
+                return const.STATION_TYPE_NDBC
         except Exception as err:
             _LOGGER.debug(
                 f"NDBC sensor discovery failed for {station_id}: {err}")
@@ -147,7 +147,7 @@ class NoaaTidesConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
                     errors=errors,
                     description_placeholders={
                         "detected_type": "NOAA Station"
-                        if self._data[const.CONF_HUB_TYPE] == const.HUB_TYPE_NOAA
+                        if self._data[const.CONF_STATION_TYPE] == const.STATION_TYPE_NOAA
                         else "NDBC Buoy",
                         "station_id": self._detected_station_id,
                     },
@@ -160,7 +160,7 @@ class NoaaTidesConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
                 errors=errors,
                 description_placeholders={
                     "detected_type": "NOAA Station"
-                    if self._data[const.CONF_HUB_TYPE] == const.HUB_TYPE_NOAA
+                    if self._data[const.CONF_STATION_TYPE] == const.STATION_TYPE_NOAA
                     else "NDBC Buoy",
                     "station_id": self._detected_station_id,
                 },
@@ -178,7 +178,7 @@ class NoaaTidesConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
                 )
 
         # Determine default name based on detected type
-        is_noaa = self._data[const.CONF_HUB_TYPE] == const.HUB_TYPE_NOAA
+        is_noaa = self._data[const.CONF_STATION_TYPE] == const.STATION_TYPE_NOAA
         default_name = (
             f"NOAA Station {self._detected_station_id}"
             if is_noaa
@@ -215,7 +215,7 @@ class NoaaTidesConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
 
     async def _discover_sensors(self) -> dict[str, str]:
         """Discover available sensors based on detected type."""
-        if self._data[const.CONF_HUB_TYPE] == const.HUB_TYPE_NOAA:
+        if self._data[const.CONF_STATION_TYPE] == const.STATION_TYPE_NOAA:
             return await discover_noaa_sensors(
                 self.hass, self._data[const.CONF_STATION_ID]
             )

--- a/custom_components/noaa_tides/const.py
+++ b/custom_components/noaa_tides/const.py
@@ -20,9 +20,9 @@ from .types import DataSectionType, TimezoneType, UnitSystemType
 DOMAIN: Final = "noaa_tides"
 PLATFORMS: Final[list[Platform]] = [Platform.SENSOR]
 
-# Hub Types
-HUB_TYPE_NOAA: Final = "noaa_station"
-HUB_TYPE_NDBC: Final = "ndbc_buoy"
+# Station Types
+STATION_TYPE_NOAA: Final = "noaa_station"
+STATION_TYPE_NDBC: Final = "ndbc_buoy"
 
 # Configuration Constants
 CONF_STATION_ID: Final = "station_id"
@@ -31,7 +31,7 @@ CONF_TIMEZONE: Final = "timezone"
 CONF_UNIT_SYSTEM: Final = "unit_system"
 CONF_UPDATE_INTERVAL: Final = "update_interval"
 CONF_DATA_SECTIONS: Final = "data_sections"
-CONF_HUB_TYPE: Final = "hub_type"
+CONF_STATION_TYPE: Final = "station_type"
 
 # Timezone Options
 TIMEZONE_GMT: Final = "gmt"

--- a/custom_components/noaa_tides/coordinator.py
+++ b/custom_components/noaa_tides/coordinator.py
@@ -32,7 +32,7 @@ class NoaaTidesDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
     def __init__(
         self,
         hass: HomeAssistant,
-        hub_type: Literal[const.HUB_TYPE_NOAA, const.HUB_TYPE_NDBC],
+        station_type: Literal[const.STATION_TYPE_NOAA, const.STATION_TYPE_NDBC],
         station_id: str,
         selected_sensors: list[str],
         timezone: str = const.DEFAULT_TIMEZONE,
@@ -44,7 +44,7 @@ class NoaaTidesDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
         Args:
             hass: The Home Assistant instance
-            hub_type: The type of hub (NOAA or NDBC)
+            station_type: The type of station (NOAA or NDBC)
             station_id: The station or buoy ID
             selected_sensors: List of selected sensor types
             timezone: The timezone setting
@@ -53,13 +53,13 @@ class NoaaTidesDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             data_sections: Selected data sections for NDBC
         """
         self.station_id: Final = station_id
-        self.hub_type: Final = hub_type
+        self.station_type: Final = station_type
         self.selected_sensors: Final = selected_sensors
         self.timezone: Final = timezone
         self.unit_system: Final = unit_system
 
         # For NDBC, determine required data sections based on selected sensors
-        if hub_type == const.HUB_TYPE_NDBC:
+        if station_type == const.STATION_TYPE_NDBC:
             self.data_sections: Final = determine_required_data_sections(
                 selected_sensors
             )
@@ -70,7 +70,7 @@ class NoaaTidesDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             self.data_sections: Final = data_sections or []
 
         # Initialize the appropriate API client
-        if hub_type == const.HUB_TYPE_NOAA:
+        if station_type == const.STATION_TYPE_NOAA:
             self.api_client: Final = NoaaApiClient(
                 hass, station_id, timezone, unit_system
             )
@@ -108,7 +108,7 @@ class NoaaTidesDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             UpdateFailed: If there's an error fetching data after retries
         """
         source_type = (
-            "NOAA station" if self.hub_type == const.HUB_TYPE_NOAA else "NDBC buoy"
+            "NOAA station" if self.station_type == const.STATION_TYPE_NOAA else "NDBC buoy"
         )
 
         try:
@@ -240,14 +240,14 @@ class NoaaTidesDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             # Format a helpful error message
             if api_error and isinstance(api_error, ApiError):
                 error_msg = (
-                    f"{'NOAA Station' if self.hub_type == const.HUB_TYPE_NOAA else 'NDBC Buoy'} "
+                    f"{'NOAA Station' if self.station_type == const.STATION_TYPE_NOAA else 'NDBC Buoy'} "
                     f"{self.station_id}: {api_error.message} (Error code: {api_error.code})"
                 )
                 if api_error.help_url:
                     error_msg += f" See {api_error.help_url} for more information."
             else:
                 error_msg = (
-                    f"{'NOAA Station' if self.hub_type == const.HUB_TYPE_NOAA else 'NDBC Buoy'} "
+                    f"{'NOAA Station' if self.station_type == const.STATION_TYPE_NOAA else 'NDBC Buoy'} "
                     f"{self.station_id}: {err}"
                 )
 

--- a/custom_components/noaa_tides/sensor.py
+++ b/custom_components/noaa_tides/sensor.py
@@ -85,10 +85,10 @@ async def async_setup_entry(
     # Clean up station name for entity ID creation
     station_name = entry.data.get("name", "").lower().replace(" ", "_")
 
-    # Determine which sensor descriptions to use based on hub type
+    # Determine which sensor descriptions to use based on station type
     sensor_types = (
         NOAA_SENSOR_TYPES
-        if coordinator.hub_type == const.HUB_TYPE_NOAA
+        if coordinator.station_type == const.STATION_TYPE_NOAA
         else NDBC_SENSOR_TYPES
     )
 
@@ -108,7 +108,7 @@ async def async_setup_entry(
         else:
             _LOGGER.warning(
                 f"Selected sensor '{sensor_id}' not found in sensor types for "
-                f"{'NOAA station' if coordinator.hub_type == const.HUB_TYPE_NOAA else 'NDBC buoy'}. Skipping."
+                f"{'NOAA station' if coordinator.station_type == const.STATION_TYPE_NOAA else 'NDBC buoy'}. Skipping."
             )
 
     if entities:
@@ -116,7 +116,7 @@ async def async_setup_entry(
         _LOGGER.debug(
             LogMessages.SENSORS_DISCOVERED.format(
                 source_type="NOAA Station"
-                if coordinator.hub_type == const.HUB_TYPE_NOAA
+                if coordinator.station_type == const.STATION_TYPE_NOAA
                 else "NDBC Buoy",
                 source_id=coordinator.station_id,
                 sensor_count=len(entities),
@@ -183,7 +183,7 @@ class NoaaTidesSensor(CoordinatorEntity[NoaaTidesDataUpdateCoordinator], SensorE
 
         # Set the native unit of measurement using the utility function
         self._attr_native_unit_of_measurement = get_unit_for_sensor(
-            description, coordinator.unit_system, coordinator.hub_type, description.key
+            description, coordinator.unit_system, coordinator.station_type, description.key
         )
 
     @property
@@ -248,7 +248,7 @@ class NoaaTidesSensor(CoordinatorEntity[NoaaTidesDataUpdateCoordinator], SensorE
                             self._attr_native_value)
                     except (ValueError, TypeError):
                         _LOGGER.debug(
-                            f"{'NOAA Station' if self.coordinator.hub_type == const.HUB_TYPE_NOAA else 'NDBC Buoy'} "
+                            f"{'NOAA Station' if self.coordinator.station_type == const.STATION_TYPE_NOAA else 'NDBC Buoy'} "
                             f"{self.coordinator.station_id}: Could not convert value '{self._attr_native_value}' "
                             f"to float for sensor {self.entity_description.key}"
                         )
@@ -279,7 +279,7 @@ class NoaaTidesSensor(CoordinatorEntity[NoaaTidesDataUpdateCoordinator], SensorE
             return sensor_data.state is not None
         except AttributeError:
             _LOGGER.debug(
-                f"{'NOAA Station' if self.coordinator.hub_type == const.HUB_TYPE_NOAA else 'NDBC Buoy'} "
+                f"{'NOAA Station' if self.coordinator.station_type == const.STATION_TYPE_NOAA else 'NDBC Buoy'} "
                 f"{self.coordinator.station_id}: Sensor data for {self.entity_description.key} "
                 f"does not have a state attribute"
             )
@@ -301,7 +301,7 @@ class NoaaTidesSensor(CoordinatorEntity[NoaaTidesDataUpdateCoordinator], SensorE
                             return True
                     except AttributeError:
                         _LOGGER.debug(
-                            f"{'NOAA Station' if self.coordinator.hub_type == const.HUB_TYPE_NOAA else 'NDBC Buoy'} "
+                            f"{'NOAA Station' if self.coordinator.station_type == const.STATION_TYPE_NOAA else 'NDBC Buoy'} "
                             f"{self.coordinator.station_id}: Related sensor data for {related_sensor} "
                             f"does not have a state attribute"
                         )

--- a/custom_components/noaa_tides/types.py
+++ b/custom_components/noaa_tides/types.py
@@ -8,8 +8,8 @@ from typing import Any, Literal, NotRequired
 
 from homeassistant.components.sensor import SensorEntityDescription
 
-# Hub Types
-HubType = Literal["noaa_station", "ndbc_buoy"]
+# Station Types
+StationType = Literal["noaa_station", "ndbc_buoy"]
 
 # Timezone Options
 TimezoneType = Literal["gmt", "lst", "lst_ldt"]
@@ -191,7 +191,7 @@ class ConfigFlowData(dict[str, Any]):
 
     name: str
     sensors: list[str]
-    hub_type: str
+    station_type: str
     station_id: NotRequired[str]  # NOAA stations
     buoy_id: NotRequired[str]  # NDBC buoys
     timezone: str

--- a/custom_components/noaa_tides/utils.py
+++ b/custom_components/noaa_tides/utils.py
@@ -32,7 +32,7 @@ from .data_constants import (
     LogMessages,
 )
 from .types import (
-    HubType,
+    StationType,
     NoaaProductResponse,
     NoaaSensorResponse,
     NoaaTidesSensorEntityDescription,
@@ -52,7 +52,7 @@ async def validate_noaa_station(hass: HomeAssistant, station_id: str) -> bool:
         bool: True if station is valid, False otherwise
 
     """
-    return await validate_data_source(hass, station_id, const.HUB_TYPE_NOAA)
+    return await validate_data_source(hass, station_id, const.STATION_TYPE_NOAA)
 
 
 async def validate_ndbc_buoy(
@@ -72,7 +72,7 @@ async def validate_ndbc_buoy(
     # Always check all sections regardless of what was passed
     all_sections = list(const.DATA_SECTIONS)
     _LOGGER.debug(f"NDBC Buoy {buoy_id}: Validating buoy ID with all data sections")
-    return await validate_data_source(hass, buoy_id, const.HUB_TYPE_NDBC, all_sections)
+    return await validate_data_source(hass, buoy_id, const.STATION_TYPE_NDBC, all_sections)
 
 
 def _deduplicate_overlapping_sensors(sensors: dict[str, str]) -> dict[str, str]:
@@ -467,17 +467,17 @@ def degrees_to_cardinal(degrees: float | None) -> str | None:
 def get_unit_for_sensor(
     sensor_description: NoaaTidesSensorEntityDescription,
     unit_system: str,
-    hub_type: str,
+    station_type: str,
     sensor_id: str,
 ) -> str | None:
-    """Get the appropriate unit for a sensor based on unit system and hub type.
+    """Get the appropriate unit for a sensor based on unit system and station type.
 
     Note: Temperature sensors no longer use this logic as HA handles conversion automatically.
 
     Args:
         sensor_description: The sensor entity description
         unit_system: The chosen unit system (UNIT_METRIC or UNIT_IMPERIAL)
-        hub_type: The hub type (HUB_TYPE_NOAA or HUB_TYPE_NDBC)
+        station_type: The station type (STATION_TYPE_NOAA or STATION_TYPE_NDBC)
         sensor_id: The sensor identifier
 
     Returns:


### PR DESCRIPTION
## Overview
Replaces "hub" terminology throughout the codebase with "station" to better reflect the integration's architecture and domain specific language.

## Problem
The integration was using "hub" terminology, but this is actually a device type integration that manages individual NOAA stations and NDBC buoys, not a hub that manages multiple devices. The "hub" terminology was:
- Architecturally misleading (not a hub integration, although was briefly)
- Inconsistent with NOAA/NDBC APIs which use "station" terminology

## Changes
- Replace `HUB_TYPE_*` constants with `STATION_TYPE_*`
- Update type definitions from `HubType` to `StationType`
- Rename variables and parameters from `hub_type` to `station_type`
- Update all conditional checks and references